### PR TITLE
Dataops 677 use cached snpseq data

### DIFF
--- a/config/app.yaml
+++ b/config/app.yaml
@@ -7,7 +7,9 @@ port: 8345
 base_url: /api/1.0
 
 # the location on the server under which runfolders are stored
-datadir: tests/resources
+# the parameters "host" and "runfolder" can be used inside curly brackets (e.g. {host}) and will be substituted
+# for each request
+datadir: tests/resources/{host}/runfolders/{runfolder}
 
 # the url where the snpseq-data service can be accessed
 snpseq_data_url: http://localhost:9191

--- a/metadata_service/handlers.py
+++ b/metadata_service/handlers.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import pathlib
+import shutil
 import tempfile
 
 import importlib.metadata
@@ -36,29 +37,50 @@ class ExportHandler:
         try:
             host = request.match_info["host"]
             runfolder = request.match_info["runfolder"]
+            lims_data = request.query.get("lims_data")
 
             runfolder_path = pathlib.Path(
-                request.app["config"].get("datadir", "."),
-                host,
-                "runfolders",
-                runfolder)
+                request.app["config"].get("datadir", ".").format(
+                    host=host,
+                    runfolder=runfolder
+                )
+            )
             metadata_export_path = os.path.join(runfolder_path, "metadata")
 
             with tempfile.TemporaryDirectory(prefix="extract", suffix="runfolder") as outdir:
-                runfolder_extract = self.process_runner.extract_runfolder_metadata(
-                    runfolder_path,
-                    outdir)
-                lims_data = await request.app['session'].request_snpseq_data_metadata(
-                    runfolder_path,
-                    outdir)
+                # unless a previous LIMS-export is passed as a parameter, do a request to the
+                # snpseq-data web service
+                if not lims_data:
+                    lims_data = await request.app['session'].request_snpseq_data_metadata(
+                        runfolder_path,
+                        outdir
+                    )
+                else:
+                    lims_data_src = pathlib.Path(
+                        metadata_export_path,
+                        lims_data
+                    )
+                    lims_data = pathlib.Path(
+                        outdir,
+                        lims_data
+                    )
+                    shutil.copy(lims_data_src, lims_data)
+
                 snpseq_data_extract = self.process_runner.extract_snpseq_data_metadata(
                     lims_data,
-                    outdir)
+                    outdir
+                )
+
+                runfolder_extract = self.process_runner.extract_runfolder_metadata(
+                    runfolder_path,
+                    outdir
+                )
 
                 metadata_export = self.process_runner.export_runfolder_metadata(
                         runfolder_extract,
                         snpseq_data_extract,
-                        metadata_export_path)
+                        metadata_export_path
+                )
 
             return aiohttp.web.json_response({'metadata': metadata_export}, status=200)
         except Exception as ex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["metadata_service*"]
 
 [project]
 name = "metadata-service"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
     {name = "SNP&SEQ Technology Platform, Uppsala University", email = "seq@medsci.uu.se" },
 ]

--- a/tests/config/app.yaml
+++ b/tests/config/app.yaml
@@ -2,6 +2,6 @@
 
 port: 9345
 base_url: /api/1.0
-datadir: tests
+datadir: tests/{host}/runfolders/{runfolder}
 snpseq_data_url: http://localhost:9191
 snpseq_metadata_executable: /Users/pontus/Documents/code/snpseq_metadata/venv_/bin/snpseq_metadata

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -22,7 +22,9 @@ async def test_snpseq_data_client(
         test_runfolder,
         test_snpseq_data_path,
         test_snpseq_data_json):
-    rq = SnpseqDataRequest(external_url=f"http://{snpseq_data_server.host}:{snpseq_data_server.port}")
+    rq = SnpseqDataRequest(
+        external_url=f"http://{snpseq_data_server.host}:{snpseq_data_server.port}"
+    )
     rq.session = aiohttp.ClientSession(rq.external_url)
     flowcell_id = rq.flowcellid_from_runfolder(test_runfolder)
     request_urls = (


### PR DESCRIPTION
This PR modifies the `snpseq-metadata-service` so that it can accept a path to a file with pre-fetched and exported data from the `snpseq-data` service instead of making an API call to the actual service.

The reason for this is that the `snpseq-data` service will be running in the local infrastructure and this service will be running on the HPC infrastructure.

